### PR TITLE
OE0-76 user districts return type ≠ on tech users

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/location/models.py
+++ b/location/models.py
@@ -1,11 +1,15 @@
 from functools import reduce
 import uuid
+
 from core import fields, filter_validity
 from django.conf import settings
 from django.db import models
 from core import models as core_models
 from graphql import ResolveInfo
 from .apps import LocationConfig
+import logging
+
+logger = logging.getLogger(__file__)
 
 
 class Location(core_models.VersionedModel):
@@ -208,7 +212,10 @@ class UserDistrict(models.Model):
         :return: UserDistrict *objects*
         """
         if not isinstance(user, core_models.InteractiveUser):
-            return []
+            if isinstance(user, core_models.TechnicalUser):
+                logger.warning(f"get_user_districts called with a technical user `{user.username}`. "
+                               "We'll return an empty list, but it should be handled before reaching here.")
+            return UserDistrict.objects.none()
         return UserDistrict.objects \
             .select_related('location') \
             .select_related('location__parent') \


### PR DESCRIPTION
The return for InteractiveUser was modified to be a queryset but the exception for other user kinds returned a list. So calls to values_list() on it failed.
We are now returning an empty queryset of the right type and we add a warning when called with a technical user as the process should not even have reached the list of districts for such a user.