### PR TITLE
OP-1021 Add possibility to input a list of uuids as a GraphQL query argument

### DIFF
--- a/location/gql_queries.py
+++ b/location/gql_queries.py
@@ -23,8 +23,8 @@ class LocationGQLType(DjangoObjectType):
             "code": ["exact", "istartswith", "icontains", "iexact"],
             "name": ["exact", "istartswith", "icontains", "iexact"],
             "type": ["exact"],
-            "parent__uuid": ["exact"],  # can't import itself!
-            "parent__id": ["exact"],  # can't import itself!
+            "parent__uuid": ["exact", "in"],  # can't import itself!
+            "parent__id": ["exact", "in"],  # can't import itself!
         }
 
     def resolve_client_mutation_id(self, info):

--- a/location/schema.py
+++ b/location/schema.py
@@ -1,6 +1,6 @@
 import graphene_django_optimizer as gql_optimizer
 
-from core.models import Officer
+from core.models import Officer, InteractiveUser
 from core.schema import OrderedDjangoFilterConnectionField
 from core.schema import signal_mutation_module_validate
 from django.db.models import Q
@@ -55,18 +55,20 @@ class Query(graphene.ObjectType):
     def resolve_locations_str(self, info, **kwargs):
         if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):
             raise PermissionDenied(_("unauthorized"))
+
+        queryset = Location.get_queryset(None, info.context.user)
         filters = [*filter_validity(**kwargs)]
+
         str = kwargs.get('str')
         if str is not None:
             filters += [Q(code__icontains=str) | Q(name__icontains=str)]
 
-        locations = Location.objects.filter(*filters)
-        #return locations
-        if info.context.user.is_officer:
+        if isinstance(info.context.user, InteractiveUser) and info.context.user.is_officer:
             officer = Officer.objects\
                 .filter(code=info.context.user.username, has_login=True, validity_to__isnull=True).get()
-            locations = locations.filter(uuid__in=officer.officer_allowed_locations)
-        return locations
+            filters += [Q(uuid__in=officer.officer_allowed_locations)]
+
+        return queryset.filter(*filters)
 
     def resolve_health_facilities_str(self, info, **kwargs):
         if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OP-1021](https://openimis.atlassian.net/browse/OP-1021)

Changes:
- Added `in` filter for parent_id and parent_uuid fields in `LocationGQLType`
- Fixed `locations_str` gql query when uisng `TechnicalUser`