### PR TITLE
Feature/op 1086: fixed region filter shadowing

### DIFF
--- a/location/gql_mutations.py
+++ b/location/gql_mutations.py
@@ -93,6 +93,8 @@ class UpdateLocationMutation(CreateOrUpdateLocationMutation):
 
     @classmethod
     def async_mutate(cls, user, **data):
+        if Location.objects.filter(code=data['code'], type=data['type'], validity_to=None).exists():
+            raise ValidationError("Location with this code already exists.")
         try:
             return cls.do_mutate(LocationConfig.gql_mutation_edit_locations_perms, user, **data)
         except Exception as exc:

--- a/location/schema.py
+++ b/location/schema.py
@@ -93,23 +93,25 @@ class Query(graphene.ObjectType):
         return queryset.filter(*filters)
 
     def resolve_health_facilities_str(self, info, **kwargs):
-        if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):
+        if not info.context.user.has_perms(
+                LocationConfig.gql_query_locations_perms
+        ):
             raise PermissionDenied(_("unauthorized"))
         filters = [*filter_validity(**kwargs)]
-        str = kwargs.get('str')
-        if str is not None:
-            filters += [Q(code__icontains=str) | Q(name__icontains=str)]
+        search = kwargs.get('str')
         district_uuid = kwargs.get('district_uuid')
         district_uuids = kwargs.get('districts_uuids')
+        region_uuid = kwargs.get('region_uuid')
+        dist = UserDistrict.get_user_districts(info.context.user._u)
+        if search is not None:
+            filters += [Q(code__icontains=search) | Q(name__icontains=search)]
         if district_uuid is not None:
             filters += [Q(location__uuid=district_uuid)]
         if district_uuids is not None:
-            filters += [Q(location__uuid__in=district_uuids)]
-
-        region_uuid = kwargs.get('region_uuid')
+            if None not in district_uuids:
+                filters += [Q(location__uuid__in=district_uuids)]
         if region_uuid is not None:
             filters += [Q(location__parent__uuid=region_uuid)]
-        dist = UserDistrict.get_user_districts(info.context.user._u)
         filters += [Q(location__id__in=[l.location_id for l in dist])]
         return HealthFacility.objects.filter(*filters)
 


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-1086

Changes:
- there was filtering for HF by district equals to [Null] and it also shadowed the 'region' filtering when district wasn't selected.

Related:
https://github.com/openimis/openimis-fe-claim_js/pull/71
https://github.com/openimis/openimis-be-claim_py/pull/68
