### PR TITLE
Ensure only discricts are returned in get_user_districts

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -307,7 +307,8 @@ class UserDistrict(core_models.VersionedModel):
                                "We'll return an empty list, but it should be handled before reaching here.")
             return UserDistrict.objects.none()
         return (
-            UserDistrict.objects.select_related("location")
+            UserDistrict.objects.filter(location__type='D')
+            .select_related("location")
             .only("location__id", "location__parent__id")
             .select_related("location__parent")
             .filter(user=user)


### PR DESCRIPTION
Additional filter for user district that exclude regions from query. Missing filter could cause regions to appear in user districts. 