### PR TITLE
Fix performance on user districts

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -299,7 +299,7 @@ class UserDistrict(core_models.VersionedModel):
             return (
                 UserDistrict.objects
                 .filter(*filter_validity())
-                .filter(location__type='D').all()
+                .filter(location__type='D')
             )
         if not isinstance(user, core_models.InteractiveUser):
             if isinstance(user, core_models.TechnicalUser):
@@ -310,11 +310,19 @@ class UserDistrict(core_models.VersionedModel):
             UserDistrict.objects.filter(location__type='D')
             .filter(location__validity_to__isnull=True)
             .select_related("location")
-            .only("location__id", "location__parent__id")
-            .select_related("location__parent")
+            .only(
+                "location__id",
+                "location__uuid",
+                "location__code",
+                "location__name",
+                "location__type",
+                "location__parent_id",
+                "location__parent__code",
+            )
+            .prefetch_related("location__parent")
             .filter(user=user)
             .filter(*filter_validity())
-            .order_by("location__parent_code")
+            .order_by("location__parent__code")
             .order_by("location__code")
             .exclude(location__parent__isnull=True)
         )


### PR DESCRIPTION
The get_user_districts was trying to be more efficient with a .only() but not fetching enough fields, triggering a n+1 query. Should also have done a prefetch_related instead of select_related (not much effect here though). In locations like DRC, this brings the user districts graphql call from 12sec to a few milliseconds !

From:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/328253/229380303-21a4da63-1193-46d7-836c-5775b150095b.png">

To:
<img width="367" alt="image" src="https://user-images.githubusercontent.com/328253/229380358-02e0b496-df5c-49e6-b468-685e6c485693.png">

