### PR TITLE
OTC-1102: changed approach for all_location Query field

### DIFF
--- a/location/gql_queries.py
+++ b/location/gql_queries.py
@@ -4,7 +4,7 @@ import base64
 from graphene_django import DjangoObjectType
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext as _
-from core import prefix_filterset, filter_validity, ExtendedConnection
+from core import prefix_filterset, ExtendedConnection
 from location.apps import LocationConfig
 from location.models import HealthFacilityLegalForm, Location, HealthFacilitySubLevel, HealthFacilityCatchment, \
     HealthFacility, UserDistrict, OfficerVillage

--- a/location/gql_queries.py
+++ b/location/gql_queries.py
@@ -47,29 +47,10 @@ class LocationGQLType(DjangoObjectType):
 
     @classmethod
     def get_queryset(cls, queryset, info):
-        return Location.get_queryset(queryset, info.context.user)
-
-
-class LocationAllGQLType(LocationGQLType):
-    class Meta:
-        model = Location
-        interfaces = (graphene.relay.Node,)
-        filter_fields = {
-            "id": ["exact"],
-            "uuid": ["exact"],
-            "code": ["exact", "istartswith", "icontains", "iexact"],
-            "name": ["exact", "istartswith", "icontains", "iexact"],
-            "type": ["exact"],
-            "parent__uuid": ["exact", "in"],  # can't import itself!
-            "parent__parent__uuid": ["exact", "in"],  # can't import itself!
-            # can't import itself!
-            "parent__parent__parent__uuid": ["exact", "in"],
-            "parent__id": ["exact", "in"],  # can't import itself!
-        }
-
-    @classmethod
-    def get_queryset(cls, queryset, info):
-        return Location.objects.filter(*filter_validity())
+        if info.field_name == "locationsAll":
+            return queryset
+        else:
+            return Location.get_queryset(queryset, info.context.user)
 
 
 class HealthFacilityLegalFormGQLType(DjangoObjectType):

--- a/location/schema.py
+++ b/location/schema.py
@@ -24,7 +24,7 @@ class Query(graphene.ObjectType):
         orderBy=graphene.List(of_type=graphene.String),
     )
     locations_all = OrderedDjangoFilterConnectionField(
-        LocationAllGQLType,
+        LocationGQLType,
         orderBy=graphene.List(of_type=graphene.String)
     )
     locations_str = DjangoFilterConnectionField(
@@ -85,16 +85,13 @@ class Query(graphene.ObjectType):
         return False if errors else True
 
     def resolve_locations(self, info, **kwargs):
-        # OMT-281 allow querying to anyone, with limitations in the get_queryset
-        # if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):
         if info.context.user.is_anonymous:
             raise PermissionDenied(_("unauthorized"))
 
     def resolve_locations_all(self, info, **kwargs):
-        # OMT-281 allow querying to anyone, with limitations in the get_queryset
-        # if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):
         if info.context.user.is_anonymous:
             raise PermissionDenied(_("unauthorized"))
+        return Location.objects.filter(validity_to__isnull=True).all()
 
     def resolve_locations_str(self, info, **kwargs):
         if info.context.user.is_anonymous:

--- a/location/schema.py
+++ b/location/schema.py
@@ -92,7 +92,7 @@ class Query(graphene.ObjectType):
     def resolve_locations_all(self, info, **kwargs):
         if info.context.user.is_anonymous:
             raise PermissionDenied(_("unauthorized"))
-        return Location.objects.filter(validity_to__isnull=True).all()
+        return Location.objects.filter(*filter_validity()).all()
 
     def resolve_locations_str(self, info, **kwargs):
         if info.context.user.is_anonymous:

--- a/location/schema.py
+++ b/location/schema.py
@@ -1,9 +1,8 @@
 import graphene_django_optimizer as gql_optimizer
 
-from core.models import Officer, InteractiveUser
+from core.models import Officer
 from core.schema import OrderedDjangoFilterConnectionField
 from core.schema import signal_mutation_module_validate
-from django.db.models import Q
 from django.utils.translation import gettext as _
 from graphene_django.filter import DjangoFilterConnectionField
 
@@ -85,6 +84,8 @@ class Query(graphene.ObjectType):
         return False if errors else True
 
     def resolve_locations(self, info, **kwargs):
+        # OMT-281 allow querying to anyone, with limitations in the get_queryset
+        # if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):
         if info.context.user.is_anonymous:
             raise PermissionDenied(_("unauthorized"))
 


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1102

Changes:
- LocationAllGQLType was deleted because it conflicted with DjangoFilterConnectionField.
When querying either the locations or locations_all fields, both get_queryset methods are invoked because they are based on the same model. To resolve this, customized the get_queryset logic for each field, considering the field attributes in the context to differentiate and adjust the returned queryset accordingly.