### PR TITLE
Allowed location excludes invalid child locations

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -105,6 +105,7 @@ class LocationManager(models.Manager):
                 "tblLocations"  child
                 INNER JOIN CTE_PARENTS leaf
                     ON child."ParentLocationId" = leaf."LocationId"
+            WHERE child."ValidityTo" is NULL
             )
             SELECT DISTINCT "LocationId" FROM CTE_PARENTS WHERE "LocationType" in ('{"','".join(loc_types)}')
         """

--- a/location/tests/test.py
+++ b/location/tests/test.py
@@ -121,6 +121,18 @@ class LocationTest(TestCase):
         districts = UserDistrict.get_user_districts(self.test_user)
         self.assertIsNotNone(districts)
 
+    def test_allowed_location_excludes_invalid(self):
+        invalid_village = create_test_village({'name': 'Invalid Vilalge', 'code': 'IV2020'})
+        invalid_village.validity_to = '2020-02-20'
+        invalid_village.parent = self.test_village.parent
+        invalid_village.save()
+
+        allowed = LocationManager().allowed(
+            self.test_user._u.id, loc_types=["V"]
+        )
+        self.assertEqual(len(allowed), 1)
+        self.assertEqual(allowed.first().id, self.test_village.id)
+
     def test_cache_invalidation(self):
         LocationManager().is_allowed(self.test_user, [])
         cached = caches["location"].get(f"user_locations_{self.test_user._u.id}")


### PR DESCRIPTION
The current implementation of `LocationManager.allowed` only exclude invalid locations from parents but not children. This PR fixes it. The before and after is illustrated in the gif below:

![allowed_locations_bug](https://github.com/user-attachments/assets/d66f8969-9447-4a82-ada4-ff6bccfbb5df)
