### PR TITLE
Fix user district parent location cache miss DB fallback

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -237,6 +237,49 @@ class LocationManager(CachedManager):
             [loc in extend_allowed_locations(allowed, strict) for loc in locations_id]
         )
 
+    def get_with_cache(self, ids, prefix="location_", timeout=None):
+        """
+        Fetch Location instances by IDs, using cache if available.
+        Falls back to DB and updates cache as needed.
+
+        :param ids: List or set of Location IDs
+        :param prefix: Cache key prefix (default: 'location_')
+        :param timeout: Optional cache timeout
+        :return: Dict of {id: Location instance}
+        """
+        if not ids:
+            return {}
+
+        ids = list(set(ids))  # ensure uniqueness and list type
+        keys = {id_: f"{prefix}{id_}" for id_ in ids}
+        cached = cache.get_many(keys.values())
+        reverse_map = {v: k for k, v in keys.items()}
+
+        result = {}
+        missing_ids = []
+
+        # Fill from cache
+        for k, loc in cached.items():
+            loc_id = reverse_map[k]
+            result[loc_id] = loc
+
+        # Track cache misses
+        for id_ in ids:
+            if id_ not in result:
+                missing_ids.append(id_)
+
+        # Fallback to DB
+        if missing_ids:
+            db_locs = self.filter(id__in=missing_ids)
+            to_cache = {}
+            for loc in db_locs:
+                result[loc.id] = loc
+                to_cache[f"{prefix}{loc.id}"] = loc
+            if to_cache:
+                cache.set_many(to_cache, timeout=timeout)
+
+        return result
+
 
 def cache_location_graph(location_id=None):
     """Cache the location graph as a dictionary of edges."""
@@ -622,22 +665,23 @@ class UserDistrict(core_models.VersionedModel):
             cache.set(f"user_districts_{user.id}", cachedata)
 
         if not districts and cachedata:
-            missing_location_ids = set()
-            for d in cachedata:
-                location = cache.get(f"location_{d[1]}")
-                if not location:
-                    logger.warning(f"district  {d[0]}:{d[1]} does not use a cached location")
-                    missing_location_ids.add(d[1])
-                else:
-                    if location.parent_id:
-                        location.parent = cache.get(f"location_{location.parent_id}")
-                    districts.append(UserDistrict(id=d[0], user=user, location=location))
+            location_ids = [d[1] for d in cachedata]
+            locations = Location.objects.get_with_cache(location_ids)
 
-            if missing_location_ids:
-                missing_locs = Location.objects.filter(id__in=missing_location_ids)
-                for loc in missing_locs:
-                    cache.set(f"location_{loc.id}", loc, timeout=None)
-                    districts.append(UserDistrict(id=0, user=user, location=loc))
+            parent_ids = {
+                loc.parent_id for loc in locations.values()
+                if loc and loc.parent_id
+            }
+            parents = Location.objects.get_with_cache(parent_ids)
+
+            for district_id, loc_id in cachedata:
+                location = locations.get(loc_id)
+                if not location:
+                    logger.warning(f"Location ID {loc_id} could not be found even after fallback")
+                    continue
+                if location.parent_id:
+                    location.parent = parents.get(location.parent_id)
+                districts.append(UserDistrict(id=district_id, user=user, location=location))
 
         return districts
 

--- a/location/tests/test.py
+++ b/location/tests/test.py
@@ -5,8 +5,7 @@ from location.test_helpers import (
     create_test_location,
     assign_user_districts,
 )
-from core.test_helpers import create_test_officer, create_test_interactive_user
-from claim.test_helpers import create_test_claim_admin
+from core.test_helpers import create_test_officer, create_test_interactive_user, create_test_claim_admin
 from django.core.cache import caches
 
 from location.models import LocationManager, UserDistrict, Location, cache, cache_location_if_not_cached
@@ -241,11 +240,25 @@ class LocationTest(TestCase):
             parent__isnull=False,
             *filter_validity(),
         )
-        self.assertTrue(all_valid_districts.count() > 0)
+        self.assertTrue(all_valid_districts.exists())
 
-        # populate cache & simulate cache eviction
+        # Manually prime location cache
         cache_location_if_not_cached()
-        cache.delete(f"location_{all_valid_districts.first().id}")
 
+        # Simulate cache eviction of a location's parent
+        example_district = all_valid_districts.first()
+        self.assertIsNotNone(example_district.parent_id)
+        cache.delete(f"location_{example_district.parent_id}")
+
+        # Also ensure no UserDistricts are cached for the user
+        cache.delete(f"user_districts_{self.test_super_user.id}")
+
+        # Invoke the method, which should handle missing parent cache gracefully
         user_districts = UserDistrict.get_user_districts(self.test_super_user)
-        self.assertEqual(len(user_districts), len(all_valid_districts))
+
+        self.assertEqual(len(user_districts), all_valid_districts.count())
+
+        # Check that all districts have a parent loaded even if it had been evicted
+        for ud in user_districts:
+            self.assertIsNotNone(ud.location)
+            self.assertIsNotNone(ud.location.parent)

--- a/location/tests/test_graphql.py
+++ b/location/tests/test_graphql.py
@@ -3,6 +3,7 @@ import json
 from dataclasses import dataclass
 import uuid
 
+from core import filter_validity
 from core.models import User
 from core.test_helpers import create_test_interactive_user
 from django.conf import settings
@@ -223,6 +224,102 @@ class LocationGQLTestCase(openIMISGraphQLTestCase):
         self.assertGreater(len(content["data"]["locations"]["edges"]), 0)
         self.assertIsNotNone(content["data"]["locations"]["edges"][0]["node"]["id"])
         self.assertIsNotNone(content["data"]["locations"]["edges"][0]["node"]["name"])
+
+    def test_locations_str_query(self):
+        invalid_village = create_test_village({'name': 'Invalid Vilalge', 'code': 'IV2020'})
+        invalid_village.validity_to = '2020-02-20'
+        invalid_village.parent = self.test_village.parent
+        invalid_village.save()
+
+        invalid_villages_qs = Location.objects.filter(type='V', code=invalid_village.code, name=invalid_village.name)
+        self.assertEquals(invalid_villages_qs.count(), 1)
+        self.assertEquals(invalid_villages_qs.filter(*filter_validity()).count(), 0)
+
+        valid_villages_qs = Location.objects.filter(type='V', code=self.test_village.code, name=self.test_village.name)
+        self.assertEquals(valid_villages_qs.count(), 1)
+        self.assertEquals(valid_villages_qs.filter(*filter_validity()).count(), 1)
+
+        query_str = """{
+          locationsStr(
+            type: "V",
+            str: ""
+          ) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            edges {
+              node {
+                id uuid code name type validityTo
+                parent {
+                  id uuid code name type
+                  parent {
+                    id uuid code name type
+                    parent {
+                      id uuid code name type
+                      parent {
+                        id uuid code name type
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }"""
+        response = self.query(
+            query_str,
+            headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"},
+        )
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        location_data = content["data"]["locationsStr"]
+
+        location_uuids = list(
+            e['node']['uuid'] for e in location_data['edges']
+        )
+        print(location_uuids)
+        self.assertTrue(
+            str(self.test_village.uuid) in location_uuids,
+            f'Expect {self.test_village.id} in {location_uuids}, but not found'
+        )
+        self.assertFalse(
+            str(invalid_village.id) in location_uuids,
+            f'Expect {invalid_village.id} not in {location_uuids}, but found'
+        )
+
+        # Check that the same works for non-admin users
+        non_admin_user = create_test_interactive_user(username="imnotadmin", roles=[1])
+        self.assertFalse(non_admin_user.is_superuser)
+        non_admin_user_token = get_token(non_admin_user, DummyContext(user=non_admin_user))
+        district_code = self.test_village.parent.parent.code
+        assign_user_districts(non_admin_user, [district_code])
+
+        response = self.query(
+            query_str,
+            headers={"HTTP_AUTHORIZATION": f"Bearer {non_admin_user_token}"},
+        )
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+        location_data = content["data"]["locationsStr"]
+        print(location_data)
+
+        location_uuids = list(
+            e['node']['uuid'] for e in location_data['edges']
+        )
+        print(location_uuids)
+        self.assertTrue(
+            str(self.test_village.uuid) in location_uuids,
+            f'Expect {self.test_village.id} in {location_uuids}, but not found'
+        )
+        self.assertFalse(
+            str(invalid_village.id) in location_uuids,
+            f'Expect {invalid_village.id} not in {location_uuids}, but found'
+        )
 
     def test_mutation_create_location(self):
         response = self.query(
@@ -584,6 +681,16 @@ class HealthFacilityGQLTestCase(GraphQLTestCase):
         content = json.loads(response.content)
         self.assertIsNotNone(content)
         self.assertResponseNoErrors(response)
+
+        districts = content["data"]["userDistricts"]
+        self.assertGreater(len(districts), 0)
+        parent = districts[0]["parent"]
+        self.assertIsNotNone(parent)
+
+        self.assertTrue(parent["id"].startswith("TG9jYXRpb25HUUxUeXBlOj"), parent["id"])  # encoded ID
+        self.assertIsInstance(parent["uuid"], str)
+        self.assertIsInstance(parent["code"], str)
+        self.assertIsInstance(parent["name"], str)
 
     def test_user_districts_not_admin(self):
 


### PR DESCRIPTION
Without this fix, when there are lots of locations, user districts' parent locations get evicted from the cache but on cache miss it didn't look up in the DB, resulting in None values for user regions. This was discovered in the UI when visiting the /front/admin/users page, replicated in regression tests.

Depends on https://github.com/openimis/openimis-be-core_py/pull/386