### PR TITLE
Fix allowed non-strict mode to not return unauthorized siblings

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -72,43 +72,72 @@ class LocationManager(CachedManager):
         return self.get_location_from_ids((parents), loc_type) if loc_type else parents
 
     def allowed(self, user_id, loc_types=["R", "D", "W", "V"], strict=True, qs=False):
-        strict_sql = """
-        AND (
-            SELECT COUNT(*) FROM USER_LOC  ul
-            WHERE ul."ParentLocationId" = parent."LocationId" ) =  (
-                SELECT COUNT(*) FROM "tblLocations" l
-                WHERE l."ParentLocationId" = parent."LocationId" AND l."ValidityTo" is Null
-            )
-        """
-        query = f"""
-            WITH {"" if settings.MSSQL else "RECURSIVE"} USER_LOC AS
-                (SELECT l."LocationId", l."ParentLocationId" FROM "tblUsersDistricts" ud
-                JOIN "tblLocations" l ON ud."LocationId" = l."LocationId"
-                WHERE ud."ValidityTo"  is Null AND "UserID" = %s ),
-             CTE_PARENTS AS (
-            SELECT
-                parent."LocationId",
-                parent."LocationType",
-                parent."ParentLocationId"
+        recursive_keyword = "" if settings.MSSQL else "RECURSIVE"
+        loc_type_list = "','".join(loc_types)
 
-            FROM
-                "tblLocations" parent
-            WHERE "LocationId" in (SELECT "LocationId" FROM USER_LOC)
-            OR (  parent."LocationId" in  (SELECT "ParentLocationId" FROM USER_LOC)
-                    {
-                        strict_sql if strict else ""})
-            UNION ALL
-            SELECT
-                child."LocationId",
-                child."LocationType",
-                child."ParentLocationId"
-            FROM
-                "tblLocations"  child
-                INNER JOIN CTE_PARENTS leaf
-                    ON child."ParentLocationId" = leaf."LocationId"
-            WHERE child."ValidityTo" is NULL
+        # Clause for strict mode: include parent only if all children are assigned
+        if strict:
+            parent_filter = """
+                SELECT parent."LocationId",
+                       parent."LocationType",
+                       parent."ParentLocationId"
+                FROM "tblLocations" parent
+                WHERE parent."LocationId" IN (
+                    SELECT "ParentLocationId" FROM USER_LOC
+                )
+                AND (
+                    SELECT COUNT(*) FROM USER_LOC ul
+                    WHERE ul."ParentLocationId" = parent."LocationId"
+                ) = (
+                    SELECT COUNT(*) FROM "tblLocations" l
+                    WHERE l."ParentLocationId" = parent."LocationId"
+                    AND l."ValidityTo" IS NULL
+                )
+            """
+        else:
+            # Include direct parents unconditionally (but don't recurse from them)
+            parent_filter = """
+                SELECT parent."LocationId",
+                       parent."LocationType",
+                       parent."ParentLocationId"
+                FROM "tblLocations" parent
+                WHERE parent."LocationId" IN (
+                    SELECT "ParentLocationId" FROM USER_LOC
+                )
+            """
+
+        query = f"""
+            WITH {recursive_keyword}
+            USER_LOC AS (
+                SELECT l."LocationId", l."ParentLocationId"
+                FROM "tblUsersDistricts" ud
+                JOIN "tblLocations" l ON ud."LocationId" = l."LocationId"
+                WHERE ud."ValidityTo" IS NULL AND "UserID" = %s
+            ),
+            PARENTS AS (
+                {parent_filter}
+            ),
+            CTE_RECURSE AS (
+                -- Start recursion from assigned locations only
+                SELECT l."LocationId", l."LocationType", l."ParentLocationId"
+                FROM "tblLocations" l
+                WHERE l."LocationId" IN (SELECT "LocationId" FROM USER_LOC)
+
+                UNION ALL
+
+                SELECT child."LocationId", child."LocationType", child."ParentLocationId"
+                FROM "tblLocations" child
+                JOIN CTE_RECURSE parent ON child."ParentLocationId" = parent."LocationId"
+                WHERE child."ValidityTo" IS NULL
+            ),
+            ALL_LOCATIONS AS (
+                SELECT * FROM CTE_RECURSE
+                UNION
+                SELECT * FROM PARENTS
             )
-            SELECT DISTINCT "LocationId" FROM CTE_PARENTS WHERE "LocationType" in ('{"','".join(loc_types)}')
+            SELECT DISTINCT "LocationId"
+            FROM ALL_LOCATIONS
+            WHERE "LocationType" IN ('{loc_type_list}')
         """
 
         if qs is not None:
@@ -122,7 +151,6 @@ class LocationManager(CachedManager):
                 location_allowed = Location.objects.filter(
                     id__in=RawSQL(query, (user_id,))
                 )
-
         else:
             location_allowed = Location.objects.raw(query, (user_id,))
 
@@ -392,7 +420,7 @@ class Location(core_models.VersionedModel, core_models.ExtendableModel):
             elif user.is_superuser:
                 return Location.objects
             else:
-                return cls.objects.allowed(user.i_user_id, qs=True)
+                return cls.objects.allowed(user.i_user_id, qs=True, strict=False)
         return queryset
 
     @staticmethod

--- a/location/tests/test.py
+++ b/location/tests/test.py
@@ -96,11 +96,41 @@ class LocationTest(TestCase):
         )
         self.assertEqual(len(district), 2)
 
-    def test_allowed_location(self):
+    def test_allowed(self):
+        allowed_ids = LocationManager().allowed(
+            self.test_user._u.id, loc_types=["V", "D", "W"], qs=True
+        ).values_list('id', flat=True)
+        self.assertTrue(self.test_village.id in allowed_ids)
+        self.assertTrue(self.test_village.parent.id in allowed_ids)
+        self.assertTrue(self.test_village.parent.parent.id in allowed_ids)
+        self.assertEqual(len(allowed_ids), 3)
+
+        allowed_ids = LocationManager().allowed(
+            self.test_user._u.id, loc_types=["R", "D", "W"], qs=True
+        ).values_list('id', flat=True)
+        self.assertTrue(self.test_village.parent.id in allowed_ids)
+        self.assertTrue(self.test_village.parent.parent.id in allowed_ids)
+        self.assertEqual(len(allowed_ids), 2)
+
+        # non-queryset
         allowed = LocationManager().allowed(
-            self.test_user._u.id, loc_types=["V", "D", "W"]
+            self.test_user._u.id, loc_types=["R", "D", "W"]
         )
-        self.assertEqual(len(allowed), 3)
+        self.assertEqual(len(allowed), 2)
+        allowed_ids_non_qs = list(l.id for l in allowed)
+        self.assertEqual(sorted(allowed_ids_non_qs), sorted(allowed_ids))
+
+        # Not strict should include parent, but not sibling
+        allowed_ids = LocationManager().allowed(
+            self.test_user._u.id, loc_types=["R", "D", "W"], qs=True, strict=False
+        ).values_list('id', flat=True)
+        self.assertTrue(self.test_village.parent.id in allowed_ids)
+        self.assertTrue(self.test_village.parent.parent.id in allowed_ids)
+        self.assertTrue(self.test_village.parent.parent.parent.id in allowed_ids)
+        self.assertFalse(self.other_loc.id in allowed_ids)
+        self.assertEqual(len(allowed_ids), 3)
+
+    def test_is_allowed(self):
         self.assertTrue(
             LocationManager().is_allowed(
                 self.test_user, [self.test_village.parent.parent.id]
@@ -115,10 +145,6 @@ class LocationTest(TestCase):
             "is_allowed function is not working as supposed",
         )
 
-        allowed = LocationManager().allowed(
-            self.test_user._u.id, loc_types=["R", "D", "W"]
-        )
-        self.assertEqual(len(allowed), 2)
         self.assertFalse(
             LocationManager().is_allowed(
                 self.test_user, [self.other_loc.id, self.test_village.parent.parent.id]


### PR DESCRIPTION
When `strict=False`, the query previously also recurse from parent which would result in unauthorized siblings being returned. The query is fixed so that it would include parent but only start recursing from explicitly assigned locations down.

With this change, location cascader respects row-level security based on user's assigned district:

![cascader_row_security](https://github.com/user-attachments/assets/63b93d60-b650-459f-9db8-4b6d6a105557)
