### PR TITLE
feat: allow locations query to filter by uuid in a provided set

### DIFF
--- a/location/gql_queries.py
+++ b/location/gql_queries.py
@@ -34,7 +34,7 @@ class LocationGQLType(DjangoObjectType):
         interfaces = (graphene.relay.Node,)
         filter_fields = {
             "id": ["exact"],
-            "uuid": ["exact"],
+            "uuid": ["exact", "in"],
             "code": ["exact", "istartswith", "icontains", "iexact", "ne"],
             "name": ["exact", "istartswith", "icontains", "iexact", "ne"],
             "type": ["exact"],

--- a/location/tests/test_graphql.py
+++ b/location/tests/test_graphql.py
@@ -319,6 +319,55 @@ class LocationGQLTestCase(openIMISGraphQLTestCase):
             f'Expect {invalid_village.id} not in {location_uuids}, but found'
         )
 
+    def test_locations_str_query_uuid_in(self):
+        """Test locationsStr query with uuid_In parameter to fetch specific locations by UUIDs"""
+        region_uuid = str(self.test_region.uuid)
+        district_uuid = str(self.test_district.uuid)
+        village_uuid = str(self.test_village.uuid)
+
+        query_str = """{
+          locationsStr(uuid_In: ["%s", "%s", "%s"]) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+            }
+            edges {
+              node {
+                id
+                uuid
+                code
+                name
+                type
+                parent {
+                  id
+                  uuid
+                  code
+                  name
+                  type
+                }
+              }
+            }
+          }
+        }""" % (region_uuid, district_uuid, village_uuid)
+
+        response = self.query(
+            query_str,
+            headers={"HTTP_AUTHORIZATION": f"Bearer {self.admin_token}"},
+        )
+
+        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        content = json.loads(response.content)
+
+        self.assertResponseNoErrors(response)
+
+        location_data = content["data"]["locationsStr"]
+        returned_uuids = [e['node']['uuid'] for e in location_data['edges']]
+
+        self.assertEqual(len(returned_uuids), 3)
+        self.assertIn(region_uuid, returned_uuids)
+        self.assertIn(district_uuid, returned_uuids)
+        self.assertIn(village_uuid, returned_uuids)
+
     def test_mutation_create_location(self):
         response = self.query(
             """


### PR DESCRIPTION
# Description

This allows fetching locations for a given set of UUIDs. Prior to this only a single UUID can be provided at a time.

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [x] Relates to https://github.com/openimis/openimis-fe-location_js/pull/102
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [x] Unit tests added/modified
- [x] I18n / translation handled
