### PR TITLE
fix(i18n): add missing %s type specifier to location/HF translation strings

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -40,31 +40,31 @@ msgstr "User not authorized for this operation"
 
 #: location/location/gql_mutations.py:93 location/gql_mutations.py:84
 msgid "location.mutation.failed_to_create_location"
-msgstr "Failed create location %(code)"
+msgstr "Failed create location %(code)s"
 
 #: location/location/gql_mutations.py:120 location/gql_mutations.py:105
 msgid "location.mutation.failed_to_update_location"
-msgstr "Failed to update location %(code)"
+msgstr "Failed to update location %(code)s"
 
 #: location/location/gql_mutations.py:165 location/gql_mutations.py:153
 msgid "location.mutation.failed_to_delete_location"
-msgstr "Failed delete location %(code)"
+msgstr "Failed delete location %(code)s"
 
 #: location/location/gql_mutations.py:207 location/gql_mutations.py:205
 msgid "location.mutation.failed_to_move_location"
-msgstr "Failed to move location %(code)"
+msgstr "Failed to move location %(code)s"
 
 #: location/location/gql_mutations.py:352 location/gql_mutations.py:290
 msgid "location.mutation.failed_to_create_health_facility"
-msgstr "Failed create health facility %(code)"
+msgstr "Failed create health facility %(code)s"
 
 #: location/location/gql_mutations.py:379 location/gql_mutations.py:324
 msgid "location.mutation.failed_to_update_health_facility"
-msgstr "Failed to update health facility %(code)"
+msgstr "Failed to update health facility %(code)s"
 
 #: location/location/gql_mutations.py:405 location/gql_mutations.py:350
 msgid "location.mutation.failed_to_delete_health_facility"
-msgstr "Failed delete health facility %(code)"
+msgstr "Failed delete health facility %(code)s"
 
 #: location/services.py:91
 msgid "mutation.location_code_duplicated"


### PR DESCRIPTION
## Summary

- 7 translation strings in `locale/en/LC_MESSAGES/django.po` used `%(code)` instead of `%(code)s`, missing the required Python `%`-style type specifier
- Whenever any exception occurred during a location or health facility mutation (e.g. duplicate code, invalid contract date range), the `except Exception` error handler called `_("location.mutation.failed_to_...") % {"code": data["code"]}`, which raised `ValueError: incomplete format`
- This secondary crash swallowed the real error, leaving Celery workers with an unhandled exception visible in Sentry as `mechanism: celery, handled: no`, and the mutation log showing `"The mutation threw a <class 'ValueError'>, check logs for details"` instead of the actual validation message

## Affected strings

| Message ID | Before | After |
|---|---|---|
| `location.mutation.failed_to_create_location` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_update_location` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_delete_location` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_move_location` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_create_health_facility` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_update_health_facility` | `%(code)` | `%(code)s` |
| `location.mutation.failed_to_delete_health_facility` | `%(code)` | `%(code)s` |

## Test plan

- [ ] Create a health facility with only `contractStartDate` set (no end date) — should return `"Contract start and end date is needed"` instead of a `ValueError`
- [ ] Create a health facility with a duplicate code — should return `"Failed create health facility <code>"` instead of a `ValueError`
- [ ] Confirm no `ValueError: incomplete format` in worker logs or Sentry after any location/HF mutation failure

Fixes: OCM-358