### PR TITLE
feat(location): add admin and GraphQL support for HF legal forms and …

### DIFF
--- a/location/admin.py
+++ b/location/admin.py
@@ -33,4 +33,3 @@ class HealthFacilitySubLevelAdmin(admin.ModelAdmin):
         if obj:
             return ["code"]
         return []
-

--- a/location/admin.py
+++ b/location/admin.py
@@ -1,1 +1,36 @@
-# Register your models here.
+from django.contrib import admin
+
+from .models import HealthFacilityLegalForm, HealthFacilitySubLevel
+
+
+@admin.register(HealthFacilityLegalForm)
+class HealthFacilityLegalFormAdmin(admin.ModelAdmin):
+    list_display = ["code", "legal_form", "sort_order", "alt_language"]
+    list_display_links = ["code", "legal_form"]
+    list_editable = ["sort_order"]
+    search_fields = ["code", "legal_form", "alt_language"]
+    ordering = ["sort_order", "code"]
+    fields = ["code", "legal_form", "sort_order", "alt_language"]
+
+    def get_readonly_fields(self, request, obj=None):
+        # Prevent changing the PK (code) after the record is created
+        if obj:
+            return ["code"]
+        return []
+
+
+@admin.register(HealthFacilitySubLevel)
+class HealthFacilitySubLevelAdmin(admin.ModelAdmin):
+    list_display = ["code", "health_facility_sub_level", "sort_order", "alt_language"]
+    list_display_links = ["code", "health_facility_sub_level"]
+    list_editable = ["sort_order"]
+    search_fields = ["code", "health_facility_sub_level", "alt_language"]
+    ordering = ["sort_order", "code"]
+    fields = ["code", "health_facility_sub_level", "sort_order", "alt_language"]
+
+    def get_readonly_fields(self, request, obj=None):
+        # Prevent changing the PK (code) after the record is created
+        if obj:
+            return ["code"]
+        return []
+

--- a/location/migrations/0019_alter_location_code.py
+++ b/location/migrations/0019_alter_location_code.py
@@ -32,12 +32,12 @@ def extract_and_drop_views(apps, schema_editor):
 def _extract_postgresql_views():
     global view_definitions
     with connection.cursor() as cursor:
-        query = """
+        query = f"""
             SELECT viewname, definition
             FROM pg_views
-            WHERE schemaname = 'public' AND viewname IN %s;
+            WHERE schemaname = 'public' AND viewname IN {tuple(DEPENDENT_VIEWS)};
         """
-        cursor.execute(query, (tuple(DEPENDENT_VIEWS),))
+        cursor.execute(query)
         for name, definition in cursor.fetchall():
             view_definitions[name] = f'CREATE OR REPLACE VIEW "public"."{name}" AS {definition}'
 

--- a/location/schema.py
+++ b/location/schema.py
@@ -19,9 +19,13 @@ from location.gql_queries import (
     UserDistrictGQLType,
     LocationGQLType,
     HealthFacilityGQLType,
+    HealthFacilityLegalFormGQLType,
+    HealthFacilitySubLevelGQLType,
 )
 from location.models import (
     HealthFacility,
+    HealthFacilityLegalForm,
+    HealthFacilitySubLevel,
     Location,
     LocationManager,
     UserDistrict,
@@ -77,6 +81,14 @@ class Query(graphene.ObjectType):
         graphene.Boolean,
         health_facility_code=graphene.String(required=True),
         description="Checks that the specified health facility code is unique.",
+    )
+    health_facility_legal_forms = graphene.List(
+        HealthFacilityLegalFormGQLType,
+        description="Returns all health facility legal forms.",
+    )
+    health_facility_sub_levels = graphene.List(
+        HealthFacilitySubLevelGQLType,
+        description="Returns all health facility sub levels.",
     )
 
     def resolve_health_facilities(self, info, **kwargs):
@@ -175,6 +187,16 @@ class Query(graphene.ObjectType):
             UserDistrictGQLType(d)
             for d in UserDistrict.get_user_districts(info.context.user._u)
         ]
+
+    def resolve_health_facility_legal_forms(self, info, **kwargs):
+        if info.context.user.is_anonymous:
+            raise PermissionDenied(_("unauthorized"))
+        return HealthFacilityLegalForm.objects.all().order_by("sort_order", "code")
+
+    def resolve_health_facility_sub_levels(self, info, **kwargs):
+        if info.context.user.is_anonymous:
+            raise PermissionDenied(_("unauthorized"))
+        return HealthFacilitySubLevel.objects.all().order_by("sort_order", "code")
 
     def resolve_officer_locations(self, info, **kwargs):
         if not info.context.user.has_perms(LocationConfig.gql_query_locations_perms):


### PR DESCRIPTION
…sub-levels

- Register `HealthFacilityLegalForm` and `HealthFacilitySubLevel` models in Django admin with list display, search, ordering, and inline editing
- Make `code` field read-only after record creation to protect the PK
- Expose new GraphQL queries `healthFacilityLegalForms` and `healthFacilitySubLevels` returning all records ordered by sort_order
- Restrict both new queries to authenticated users only


A clear, concise description of the change. Why is it needed? What problem does it solve?

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
